### PR TITLE
reinsert jsonfield (glossary)

### DIFF
--- a/djangocms_history/helpers.py
+++ b/djangocms_history/helpers.py
@@ -74,6 +74,8 @@ def get_plugin_data(plugin, only_meta=False):
     else:
         plugin_fields = get_plugin_fields(plugin.plugin_type)
         _plugin_data = serializers.serialize('python', (plugin,), fields=plugin_fields)[0]
+        if "glossary" in plugin_fields:
+            _plugin_data['fields']['glossary']=plugin.glossary
         custom_data = _plugin_data['fields']
 
     plugin_data = {


### PR DESCRIPTION
### Summary
when serializing fields in python format, the json formatting is transformed and becomes incomptatible with djangocms-cascade.

Fixes #
for example:
{'content': 'test'} became '{"content": "test"}' 



### Links to related discussion
https://github.com/divio/djangocms-history/issues/20
https://github.com/jrief/djangocms-cascade/pull/281


### Proposed changes in this pull request
These changes are the proof of concept that solves the problem for djangocms-cascade.
Perhaps something more generic would have to be found for this to be integrated in the branch