### PR TITLE
do not altered fields

### DIFF
--- a/djangocms_history/helpers.py
+++ b/djangocms_history/helpers.py
@@ -73,8 +73,12 @@ def get_plugin_data(plugin, only_meta=False):
         custom_data = None
     else:
         plugin_fields = get_plugin_fields(plugin.plugin_type)
-        _plugin_data = serializers.serialize('python', (plugin,), fields=plugin_fields)[0]
-        custom_data = _plugin_data['fields']
+        plugin_data_fields ={}
+        for i in plugin_fields:
+            if i != 'cmsplugin_ptr':
+                plugin_data_fields[i]=plugin.__getattribute__(i)
+
+        custom_data = OrderedDict(plugin_data_fields)
 
     plugin_data = {
         'pk': plugin.pk,

--- a/djangocms_history/helpers.py
+++ b/djangocms_history/helpers.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from datetime import timedelta
 
 from django.contrib.sites.models import Site


### PR DESCRIPTION
### Summary
when serializing fields in python format, the json formatting is transformed and becomes incomptatible.

Fixes #
for example:
{'content': 'test'} became '{"content": "test"}' 



### Links to related discussion
https://github.com/divio/djangocms-history/issues/20
https://github.com/jrief/djangocms-cascade/pull/281


### Proposed changes in this pull request
These changes are the proof of concept that solves the problem for djangocms-cascade.